### PR TITLE
Housekeeping

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,32 +2,27 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev ]
   pull_request:
     branches: [ master ]
 
 jobs:
 
   build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
 
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: ^1.13
+        go-version-file: './go.mod'
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
+      uses: actions/checkout@v3
 
     - name: Build
       run: go build -v .
@@ -37,4 +32,3 @@ jobs:
 
     - name: Format
       run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
-

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,4 +31,5 @@ jobs:
       run: go test -v -coverprofile coverage.out && go tool cover -html coverage.out -o coverage.html
 
     - name: Format
+      if: matrix.os == "ubuntu-latest"
       run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
       run: go build -v .
 
     - name: Test
-      run: go test -v .
+      run: go test -v -coverprofile coverage.out && go tool cover -html coverage.out -o coverage.html
 
     - name: Format
       run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ master, dev ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -31,5 +31,9 @@ jobs:
       run: go test -v -coverprofile coverage.out && go tool cover -html coverage.out -o coverage.html
 
     - name: Format
-      if: matrix.os == "ubuntu-latest"
+      if: matrix.os == 'ubuntu-latest'
       run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
+
+    - name: Upload coverage to Codecov
+      if: matrix.os == 'ubuntu-latest'
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version-file: './go.mod'
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Build
       run: go build -v .

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+*.html
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 * [Named colors](https://www.w3.org/TR/css-color-4/#named-colors)
 * RGB hexadecimal (with and without `#` prefix)
-     + Short format `#rgb`
-     + Short format with alpha `#rgba`
-     + Long format `#rrggbb`
-     + Long format with alpha `#rrggbbaa`
+  * Short format `#rgb`
+  * Short format with alpha `#rgba`
+  * Long format `#rrggbb`
+  * Long format with alpha `#rrggbbaa`
 * `rgb()` and `rgba()`
 * `hsl()` and `hsla()`
 * `hwb()`
@@ -26,7 +26,7 @@ Not yet supported: `lab()`, `lch()`.
 
 ### Example Color Format
 
-```
+```css
 transparent
 lime
 #0f0
@@ -61,7 +61,7 @@ import "github.com/mazznoer/csscolorparser"
 c, err := csscolorparser.Parse("gold")
 
 if err != nil {
-	panic(err)
+ panic(err)
 }
 
 fmt.Printf("R:%.3f, G:%.3f, B:%.3f, A:%.3f", c.R, c.G, c.B, c.A) // R:1.000, G:0.843, B:0.000, A:1.000
@@ -79,4 +79,3 @@ fmt.Println(c.RGBString()) // rgb(255,215,0)
 
 * [csscolorparser](https://github.com/mazznoer/csscolorparser-rs) (Rust)
 * [csscolorparser](https://github.com/deanm/css-color-parser-js) (Javascript)
-

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mazznoer/csscolorparser
 
-go 1.15
+go 1.12


### PR DESCRIPTION
## Changes

- Set minimum Go version to 1.12 (implied from travis ci file)
- gitignore go test *.html test coverage report
- CI on all 3 OSes (windows, macos, linux)
- Linted README with markdownlint
- Run test coverage in CI (current test coverage is **80.5%**); codecov badge is outdated.
- Added codecov github action to CI; enable codecov GitHub permissions on this repo and your badge will be updated.