### PR TITLE
fix: Make `Color.Name` returns `false` if a color has the same RGB as a named color, but is not fully opaque

### DIFF
--- a/colorparser.go
+++ b/colorparser.go
@@ -62,7 +62,10 @@ func (c Color) RGBString() string {
 
 // Name returns name of this color if its available.
 func (c Color) Name() (string, bool) {
-	r, g, b, _ := c.RGBA255()
+	r, g, b, a := c.RGBA255()
+	if a != 255 {
+		return "", false
+	}
 	rgb := [3]uint8{r, g, b}
 	for k, v := range namedColors {
 		if v == rgb {

--- a/named_colors_test.go
+++ b/named_colors_test.go
@@ -72,4 +72,35 @@ func Test_NamedColors(t *testing.T) {
 		test(t, ok, false)
 		test(t, name, "")
 	}
+
+	// 8 digits hex code with fully opaque alpha component
+
+	data3 := [][2]string{
+		{"#f0f8ffff", "aliceblue"},
+		{"#ffe4c4ff", "bisque"},
+		{"#7fff00ff", "chartreuse"},
+		{"#ff7f50ff", "coral"},
+	}
+	for _, d := range data3 {
+		c, err := Parse(d[0])
+		test(t, err, nil)
+		name, ok := c.Name()
+		testTrue(t, ok)
+		test(t, name, d[1])
+	}
+
+	// RGB is the same as named colors, but is not fully opaque
+
+	data4 := []string{
+		"#f0f8ff3f",
+		"#ffe4c47f",
+		"#7fff00bf",
+	}
+	for _, s := range data4 {
+		c, err := Parse(s)
+		test(t, err, nil)
+		name, ok := c.Name()
+		test(t, ok, false)
+		test(t, name, "")
+	}
 }


### PR DESCRIPTION
Named colors are represented the 6 digits hex color notation, and the alpha component of this is fully opaque.[^1][^2]

[^1]: <https://www.w3.org/TR/css-color-4/#named-colors>
[^2]: <https://www.w3.org/TR/css-color-4/#hex-notation>